### PR TITLE
feat: Support git in package source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,9 @@ which = "4.4.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.12"
-cargo-husky = { version = "1.5.0", default-features = false, features = ["user-hooks"] }
+cargo-husky = { version = "1.5.0", default-features = false, features = [
+  "user-hooks",
+] }
 insta = { version = "1.31.0", features = ["yaml"] }
 
 [package.metadata.bin]
@@ -44,7 +46,10 @@ committed = { version = "1.0.20" }
 dprint = { version = "0.40.2" }
 git-cliff = { version = "1.2.0" }
 # Just added for testing
-dustinblackman-hello-world = { version = "0.2.1", bins = ["hello-world-first", "hello-world-second"] }
+dustinblackman-hello-world = { version = "0.2.1", git = "https://github.com/dustinblackman/rust-hello-world", bins = [
+  "hello-world-first",
+  "hello-world-second",
+] }
 
 [profile.dev.package.insta]
 opt-level = 3
@@ -65,12 +70,20 @@ inherits = "release"
 cargo-dist-version = "0.1.0-prerelease.10"
 ci = ["github"]
 installers = []
-targets = ["x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "aarch64-apple-darwin"]
+targets = [
+  "x86_64-unknown-linux-gnu",
+  "x86_64-apple-darwin",
+  "aarch64-apple-darwin",
+]
 unix-archive = ".tar.gz"
 
 # Config for 'cargo release'
 [package.metadata.release]
-pre-release-hook = ["bash", "-c", "cargo cmd lint && cargo cmd test && cargo bin git-cliff -o CHANGELOG.md --tag {{version}} && cargo bin dprint fmt"]
+pre-release-hook = [
+  "bash",
+  "-c",
+  "cargo cmd lint && cargo cmd test && cargo bin git-cliff -o CHANGELOG.md --tag {{version}} && cargo bin dprint fmt",
+]
 allow-branch = ["master"]
 
 [package.metadata.commands]

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -34,6 +34,17 @@ pub fn cargo_install(
         .arg("--version")
         .arg(binary_package.version);
 
+    if let Some(git) = &binary_package.git {
+        cmd_prefix.arg("--git").arg(git);
+        if let Some(branch) = &binary_package.branch {
+            cmd_prefix.arg("--branch").arg(branch);
+        } else if let Some(tag) = &binary_package.tag {
+            cmd_prefix.arg("--tag").arg(tag);
+        } else if let Some(rev) = &binary_package.rev {
+            cmd_prefix.arg("--rev").arg(rev);
+        }
+    }
+
     if let Some(bin_target) = &binary_package.bin_target {
         cmd_prefix.arg("--bin").arg(bin_target);
     }
@@ -75,6 +86,10 @@ pub fn binstall(binary_package: metadata::BinaryPackage, cache_path: path::PathB
         .arg(&cache_path)
         .arg("--install-path")
         .arg(cache_path.join("bin"));
+
+    if let Some(git) = &binary_package.git {
+        cmd_prefix.arg("--git").arg(git);
+    }
 
     if let Some(locked) = &binary_package.locked {
         if *locked {
@@ -120,6 +135,9 @@ pub fn install(binary_package: metadata::BinaryPackage) -> Result<String> {
         if binary_package.bin_target.is_none()
             && binary_package.features.is_none()
             && binary_package.default_features.is_none()
+            && binary_package.branch.is_none()
+            && binary_package.tag.is_none()
+            && binary_package.rev.is_none()
             && binary_package.package != "cargo-binstall"
             && (cargo_config::binstall_alias_exists()? || which("cargo-binstall").is_ok())
         {

--- a/src/binary_test.rs
+++ b/src/binary_test.rs
@@ -30,6 +30,31 @@ mod cargo_install {
                 package: "dustinblackman-hello-world".to_string(),
                 locked: None,
                 version: "0.1.0".to_string(),
+                git: None,
+                branch: None,
+                tag: None,
+                rev: None,
+                default_features: None,
+                features: None,
+            },
+            "./target/debug".into(),
+        );
+
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn it_builds_successfully_with_git() {
+        let res = cargo_install(
+            metadata::BinaryPackage {
+                bin_target: None,
+                package: "dustinblackman-hello-world".to_string(),
+                locked: None,
+                version: "0.2.0".to_string(),
+                git: Some("https://github.com/dustinblackman/rust-hello-world".to_string()),
+                branch: None,
+                tag: None,
+                rev: Some("8a1cd3d2538460d1e8920bf86cf6e2aa982eb69d".to_string()),
                 default_features: None,
                 features: None,
             },
@@ -51,6 +76,31 @@ mod binstall {
                 package: "dustinblackman-hello-world".to_string(),
                 locked: None,
                 version: "0.1.0".to_string(),
+                git: None,
+                branch: None,
+                tag: None,
+                rev: None,
+                default_features: None,
+                features: None,
+            },
+            "./target/debug".into(),
+        );
+
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn it_builds_successfully_with_git() {
+        let res = binstall(
+            metadata::BinaryPackage {
+                bin_target: None,
+                package: "dustinblackman-hello-world".to_string(),
+                locked: None,
+                version: "0.1.0".to_string(),
+                git: Some("https://github.com/dustinblackman/rust-hello-world".to_string()),
+                branch: None,
+                tag: None,
+                rev: None,
                 default_features: None,
                 features: None,
             },

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -17,6 +17,10 @@ mod metadata_test;
 #[derive(Deserialize, Debug, PartialEq)]
 struct MetadataValue {
     version: String,
+    git: Option<String>,
+    branch: Option<String>,
+    tag: Option<String>,
+    rev: Option<String>,
     locked: Option<bool>,
     bins: Option<Vec<String>>,
     #[serde(alias = "default-features")]
@@ -32,6 +36,10 @@ pub struct BinaryPackage {
     pub package: String,
     pub locked: Option<bool>,
     pub version: String,
+    pub git: Option<String>,
+    pub branch: Option<String>,
+    pub tag: Option<String>,
+    pub rev: Option<String>,
     pub default_features: Option<bool>,
     pub features: Option<Vec<String>>,
 }
@@ -95,6 +103,10 @@ pub fn get_binary_packages() -> Result<Vec<BinaryPackage>> {
                     package: pkg_name.clone(),
                     locked: pkg_details.locked,
                     version: pkg_details.version.clone(),
+                    git: pkg_details.git.clone(),
+                    branch: pkg_details.branch.clone(),
+                    tag: pkg_details.tag.clone(),
+                    rev: pkg_details.rev.clone(),
                     default_features: pkg_details.default_features,
                     features: pkg_details.features.clone(),
                 });
@@ -105,6 +117,10 @@ pub fn get_binary_packages() -> Result<Vec<BinaryPackage>> {
                 package: pkg_name,
                 locked: pkg_details.locked,
                 version: pkg_details.version,
+                git: pkg_details.git,
+                branch: pkg_details.branch,
+                tag: pkg_details.tag,
+                rev: pkg_details.rev,
                 default_features: pkg_details.default_features,
                 features: pkg_details.features,
             });

--- a/src/metadata_test.rs
+++ b/src/metadata_test.rs
@@ -28,6 +28,10 @@ mod get_binary_packages {
         let res = android.unwrap();
         assert_eq!(&res.package, "dustinblackman-hello-world");
         assert_ne!(&res.version, "");
+        assert_eq!(
+            &res.git,
+            &Some("https://github.com/dustinblackman/rust-hello-world".to_string())
+        );
         assert_eq!(res.bin_target.clone().unwrap(), "hello-world-first");
     }
 }


### PR DESCRIPTION
This will add support for `git` property (as well as related `branch`, `tag` and `rev`) within the binary package definition.

Related to: https://github.com/dustinblackman/cargo-run-bin/issues/9.