### PR TITLE
chore: `tauri-mobile` -> `cargo-mobile2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ table. A quick example taken from this repo:
 cargo-binstall = { version = "1.1.2" }
 cargo-nextest = { version = "0.9.57", locked = true }
 dprint = { version = "0.30.3" }
-tauri-mobile = { version = "0.5.2", bins = ["cargo-android", "cargo-mobile"], locked = true }
+cargo-mobile2 = { version = "0.5.2", bins = ["cargo-android", "cargo-mobile"], locked = true }
 ```
 
 Or if you're setting up in a workspace:
@@ -54,7 +54,7 @@ cargo-nextest = { version = "0.9.57", locked = true }
 | Parameter        | Type          | Required | Description                                                                                                                                                                                                                                                             |
 | ---------------- | ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | version          | `String`      | true     | Specifies the version of the crate.                                                                                                                                                                                                                                     |
-| bins             | `Vec<String>` | false    | An array of binaries that the crate contains that you wish to build. These can be found in a crates `Cargo.toml` file. See [`tauri-mobile`](https://github.com/tauri-apps/tauri-mobile/blob/a5f3783870f48886e3266e43f92a6768fb1eb3d4/Cargo.toml#L18-L28) as an example. |
+| bins             | `Vec<String>` | false    | An array of binaries that the crate contains that you wish to build. These can be found in a crates `Cargo.toml` file. See [`cargo-mobile2`](https://github.com/tauri-apps/cargo-mobile2/blob/a5f3783870f48886e3266e43f92a6768fb1eb3d4/Cargo.toml#L18-L28) as an example. |
 | locked           | `Boolean`     | false    | A parameter when set to `true` runs `cargo install` with the [`--locked`](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile) parameter.                                                                                             |
 | features         | `Vec<String>` | false    | An array of crate features to enable.                                                                                                                                                                                                                                   |
 | default-features | `Boolean`     | false    | When set to `false`, disables all default features.                                                                                                                                                                                                                     |


### PR DESCRIPTION
We have recently renamed `tauri-mobile` project to `cargo-mobile2` for SEO reasons.