### PR TITLE
Self hosting the cli to remove global installation

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
-bin = ["run", "--"]
+bin = ["run", "--package", "cargo-bin", "--"]
 cmd = ["bin", "cargo-cmd"]
 deny = ["bin", "cargo-deny"]
 gha = ["bin", "cargo-gha"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,5 @@
 [alias]
+bin = ["run", "--"]
 cmd = ["bin", "cargo-cmd"]
 deny = ["bin", "cargo-deny"]
 gha = ["bin", "cargo-gha"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
 
       - name: Install deps
         run: |
-          cargo install cargo-run-bin --target-dir ./target
           cargo bin --build
           cargo cmd setup-nightly
       - name: Lint
@@ -47,7 +46,6 @@ jobs:
           cache-directories: ".bin"
       - name: Install deps
         run: |
-          cargo install --path .
           cargo nextest --help
       - name: Test
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-bin"
+version = "0.0.0"
+dependencies = [
+ "cargo-run-bin 1.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cargo-husky"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +112,23 @@ dependencies = [
  "cfg-if",
  "clap",
  "insta",
+ "rustversion",
+ "serde",
+ "toml",
+ "toml_edit",
+ "version_check",
+ "which",
+]
+
+[[package]]
+name = "cargo-run-bin"
+version = "1.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0770bfdecb25f182aa143e443765b8ecf6f0e6431d8c42ad997b17900c9b6c48"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "clap",
  "rustversion",
  "serde",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,3 +147,6 @@ test = '''set -e
 test-watch = '''set -e
   cargo watch -i .cargo -x 'cmd test'
 '''
+
+[workspace]
+members = ["tools/cargo-bin"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Installing with a minimal wrapper and an alias.
 ```sh
 cd my/rust/project
 echo ".bin/" >> .gitignore
-cargo new --bin cargo-bin
+cargo new --bin tools/cargo-bin
 cd cargo-bin
 cargo add --features cli cargo-run-bin
 ```

--- a/README.md
+++ b/README.md
@@ -42,6 +42,49 @@ You can also use it as a library within your existing logic.
 cargo-run-bin = { version = "1.7.2", default-features = false }
 ```
 
+### Using wrapper
+
+Installing with a minimal wrapper and an alias. 
+
+```sh
+cd my/rust/project
+echo ".bin/" >> .gitignore
+cargo new --bin cargo-bin
+cd cargo-bin
+cargo add --features cli cargo-run-bin
+```
+
+Call the cli in the wrapper `my/rust/project/cargo-bin/src/main.rs`
+
+```rust
+use std::process;
+
+fn main() {
+    if let Err(res) = cargo_run_bin::cli::run() {
+        eprintln!("\x1b[31m{}\x1b[0m", format!("run-bin failed: {res}"));
+        process::exit(1);
+    }
+}
+```
+
+Ensure the binary is added to the workspace.
+
+```toml
+[workspace]
+members = ["cargo-bin"]
+```
+
+Now add an alias
+
+```toml
+[alias]
+bin = ["run", "--package", "cargo-bin", "--"]
+```
+Now it can be used as if installed globally 
+```sh
+cargo bin --version
+```
+
 ### Distro packages
 
 <details>

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Installing with a minimal wrapper and an alias.
 ```sh
 cd my/rust/project
 echo ".bin/" >> .gitignore
-cargo new --bin tools/cargo-bin
+cargo new --vcs none --bin tools/cargo-bin
 curl --output tools/cargo-bin/src/main.rs https://raw.githubusercontent.com/dustinblackman/cargo-run-bin/refs/tags/v1.7.4/src/main.rs
 cd tools/cargo-bin
 cargo add --features cli cargo-run-bin

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can also use it as a library within your existing logic.
 
 ```toml
 [dependencies]
-cargo-run-bin = { version = "1.7.2", default-features = false }
+cargo-run-bin = { version = "1.7.4", default-features = false }
 ```
 
 ### Using wrapper
@@ -50,21 +50,9 @@ Installing with a minimal wrapper and an alias.
 cd my/rust/project
 echo ".bin/" >> .gitignore
 cargo new --bin tools/cargo-bin
+curl --output tools/cargo-bin/src/main.rs https://raw.githubusercontent.com/dustinblackman/cargo-run-bin/refs/tags/v1.7.4/src/main.rs
 cd tools/cargo-bin
 cargo add --features cli cargo-run-bin
-```
-
-Call the cli in the wrapper `my/rust/project/cargo-bin/src/main.rs`
-
-```rust
-use std::process;
-
-fn main() {
-    if let Err(res) = cargo_run_bin::cli::run() {
-        eprintln!("\x1b[31m{}\x1b[0m", format!("run-bin failed: {res}"));
-        process::exit(1);
-    }
-}
 ```
 
 Ensure the binary is added to the workspace.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Installing with a minimal wrapper and an alias.
 cd my/rust/project
 echo ".bin/" >> .gitignore
 cargo new --bin tools/cargo-bin
-cd cargo-bin
+cd tools/cargo-bin
 cargo add --features cli cargo-run-bin
 ```
 
@@ -71,7 +71,7 @@ Ensure the binary is added to the workspace.
 
 ```toml
 [workspace]
-members = ["cargo-bin"]
+members = ["tools/cargo-bin"]
 ```
 
 Now add an alias

--- a/tools/cargo-bin/Cargo.toml
+++ b/tools/cargo-bin/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "cargo-bin"
+
+[dependencies]
+cargo-run-bin = { version = "1.7.2", features = ["cli"]}

--- a/tools/cargo-bin/Cargo.toml
+++ b/tools/cargo-bin/Cargo.toml
@@ -2,4 +2,4 @@
 name = "cargo-bin"
 
 [dependencies]
-cargo-run-bin = { version = "1.7.2", features = ["cli"]}
+cargo-run-bin = { version = "1.7.4", features = ["cli"]}

--- a/tools/cargo-bin/src/main.rs
+++ b/tools/cargo-bin/src/main.rs
@@ -1,0 +1,12 @@
+use std::process;
+
+fn main() {
+    let res = cargo_run_bin::cli::run();
+
+    // Only reached if run-bin code fails, otherwise process exits early from within
+    // binary::run.
+    if let Err(res) = res {
+        eprintln!("\x1b[31m{}\x1b[0m", format!("run-bin failed: {res}"));
+        process::exit(1);
+    }
+}


### PR DESCRIPTION
Hi,

Love the project. :+1: 

Just as an example, with an alias the cli can be self-hosted and used directly without the need to install it globally.

With a tiny bit of code it can be used the same in a project also removing the need to globally install.
Here is an example using it like that.

https://gitlab.com/zerotacg/learning-rust-webapp/-/tree/main/cargo-bin

If we add a main function to the cli library the boilerplate code in the project code further be reduced.

Is that a direction that would be interesting for the project?
